### PR TITLE
Refactor: TSrim部分のコードの整理

### DIFF
--- a/TSrim.cc
+++ b/TSrim.cc
@@ -24,171 +24,18 @@ using namespace amdc;
 
 ClassImp(TSrim);
 ///////////////////////////////////////////////////////////////////////////////
-TSrim::TSrim() : Nmat(0) {};
+TSrim::TSrim() : Nmat(0) {
+}
 TSrim::TSrim(const char *name, const Int_t npol, const char *datafile) : Nmat(0) {
-    TString fn_name = Form("pol%d", npol);
-    Double_t dummy;
-    Int_t Z, A;
-    TString mat;
-    Double_t par[npol + 1];
-    vector<Int_t> vZ, vA;
-    vector<TString> vmat;
-    vector<Double_t> vpar[npol + 1];
-    std::ifstream fpar(datafile);
-    while (!fpar.eof()) {
-        fpar >> Z >> A >> mat;
-        for (Int_t j = 0; j < npol + 1; j++)
-            fpar >> par[j];
-        fpar >> dummy >> dummy;
-        if (fpar.eof())
-            break;
-        vZ.emplace_back(Z);
-        vA.emplace_back(A);
-        vmat.emplace_back(mat);
-        for (Int_t j = 0; j < npol + 1; j++)
-            vpar[j].emplace_back(par[j]);
-    }
-    fpar.close();
-    if (vZ.size() == 0) {
-        std::cout << "No isotope data loaded." << std::endl;
-    }
-
-    Int_t self_index = 0;
-    for (Size_t i = 0; i < vZ.size(); i++) {
-        /// register the mapping
-        // Do nothing if the key already exists
-        auto mat_result = mat_mapping.insert({std::string(vmat.at(i).Data()), Nmat});
-        if (mat_result.second)
-            Nmat++;
-
-        if (auto it = mat_mapping.find(std::string(vmat.at(i).Data())); it != mat_mapping.end()) {
-            auto result = self_mapping.insert({get_key(vZ.at(i), vA.at(i), it->second), self_index});
-            if (!result.second) {
-                std::cerr << "Key already exists with index: " << result.first->second << std::endl;
-            } else {
-                this->emplace_back(TF1(Form("%d-%d_%s", vZ.at(i), vA.at(i), vmat.at(i).Data()),
-                                       fn_name.Data(), TSrim::log10Emin,
-                                       TSrim::log10Emaxpu * Mass(Z, A)));
-                for (Int_t j = 0; j < npol + 1; j++) {
-                    this->at(self_index).SetParameter(j, vpar[j].at(i));
-                }
-                self_index++;
-            }
-        }
-    }
-    // TSrim(name, npol, datafile, 1, 1, 20, 40);
-};
+    TSrim::AddElement(name, npol, datafile);
+}
 TSrim::TSrim(const char *name, const Int_t npol, const char *datafile, Int_t Z, Int_t A) : Nmat(0) {
-    TString fn_name = Form("pol%d", npol);
-    Double_t dummy;
-    Int_t Zdat, Adat;
-    TString mat;
-    Double_t par[npol + 1];
-    vector<Int_t> vZ, vA;
-    vector<TString> vmat;
-    vector<Double_t> vpar[npol + 1];
-    std::ifstream fpar(datafile);
-    while (!fpar.eof()) {
-        fpar >> Zdat >> Adat >> mat;
-        for (Int_t j = 0; j < npol + 1; j++)
-            fpar >> par[j];
-        fpar >> dummy >> dummy;
-        if (fpar.eof()) {
-            break;
-        }
-        if (Zdat == Z && Adat == A) {
-            vZ.emplace_back(Z);
-            vA.emplace_back(A);
-            vmat.emplace_back(mat);
-            for (Int_t j = 0; j < npol + 1; j++)
-                vpar[j].emplace_back(par[j]);
-            break;
-        }
-    }
-    fpar.close();
-    if (vZ.size() == 0) {
-        std::cout << "No isotope data loaded." << std::endl;
-    }
-
-    Int_t self_index = 0;
-    for (Size_t i = 0; i < vZ.size(); i++) {
-        /// register the mapping
-        // Do nothing if the key already exists
-        auto mat_result = mat_mapping.insert({std::string(vmat.at(i).Data()), Nmat});
-        if (mat_result.second)
-            Nmat++;
-
-        if (auto it = mat_mapping.find(std::string(vmat.at(i).Data())); it != mat_mapping.end()) {
-            auto result = self_mapping.insert({get_key(vZ.at(i), vA.at(i), it->second), self_index});
-            if (!result.second) {
-                std::cerr << "Key already exists with index: " << result.first->second << std::endl;
-            } else {
-                this->emplace_back(TF1(Form("%d-%d_%s", vZ.at(i), vA.at(i), vmat.at(i).Data()),
-                                       fn_name.Data(), TSrim::log10Emin,
-                                       TSrim::log10Emaxpu * Mass(Z, A)));
-                for (Int_t j = 0; j < npol + 1; j++) {
-                    this->at(self_index).SetParameter(j, vpar[j].at(i));
-                }
-                self_index++;
-            }
-        }
-    }
-};
+    TSrim::AddElement(name, npol, datafile, Z, A);
+}
 TSrim::TSrim(const char *name, const Int_t npol, const char *datafile,
              Int_t Zmin, Int_t Amin, Int_t Zmax, Int_t Amax) : Nmat(0) {
-    TString fn_name = Form("pol%d", npol);
-    Double_t dummy;
-    Int_t Z, A;
-    TString mat;
-    Double_t par[npol + 1];
-    vector<Int_t> vZ, vA;
-    vector<TString> vmat;
-    vector<Double_t> vpar[npol + 1];
-    std::ifstream fpar(datafile);
-    while (!fpar.eof()) {
-        fpar >> Z >> A >> mat;
-        for (Int_t j = 0; j < npol + 1; j++)
-            fpar >> par[j];
-        fpar >> dummy >> dummy;
-        if (fpar.eof())
-            break;
-        if (Z >= Zmin && A >= Amin && Z <= Zmax && A <= Amax) {
-            vZ.emplace_back(Z);
-            vA.emplace_back(A);
-            vmat.emplace_back(mat);
-            for (Int_t j = 0; j < npol + 1; j++)
-                vpar[j].emplace_back(par[j]);
-        }
-    }
-    fpar.close();
-    if (vZ.size() == 0) {
-        std::cout << "No isotope data loaded." << std::endl;
-    }
-
-    Int_t self_index = 0;
-    for (Size_t i = 0; i < vZ.size(); i++) {
-        /// register the mapping
-        // Do nothing if the key already exists
-        auto mat_result = mat_mapping.insert({std::string(vmat.at(i).Data()), Nmat});
-        if (mat_result.second)
-            Nmat++;
-
-        if (auto it = mat_mapping.find(std::string(vmat.at(i).Data())); it != mat_mapping.end()) {
-            auto result = self_mapping.insert({get_key(vZ.at(i), vA.at(i), it->second), self_index});
-            if (!result.second) {
-                std::cerr << "Key already exists with index: " << result.first->second << std::endl;
-            } else {
-                this->emplace_back(TF1(Form("%d-%d_%s", vZ.at(i), vA.at(i), vmat.at(i).Data()),
-                                       fn_name.Data(), TSrim::log10Emin,
-                                       TSrim::log10Emaxpu * Mass(Z, A)));
-                for (Int_t j = 0; j < npol + 1; j++) {
-                    this->at(self_index).SetParameter(j, vpar[j].at(i));
-                }
-                self_index++;
-            }
-        }
-    }
-};
+    TSrim::AddElement(name, npol, datafile, Zmin, Amin, Zmax, Amax);
+}
 ///////////////////////////////////////////////////////////////////////////////
 Double_t TSrim::Range(Int_t Z, Int_t A, Double_t E, TString mat) {
     if (E <= TSrim::Emin) {
@@ -580,140 +427,48 @@ void TSrim::ShowMatNuclList() {
 }
 
 void TSrim::AddElement(const char *name, const Int_t npol, const char *datafile) {
-    TString fn_name = Form("pol%d", npol);
-    Double_t dummy;
-    Int_t Z, A;
-    TString mat;
-    Double_t par[npol + 1];
-    vector<Int_t> vZ, vA;
-    vector<TString> vmat;
-    vector<Double_t> vpar[npol + 1];
-    std::ifstream fpar(datafile);
-    while (!fpar.eof()) {
-        fpar >> Z >> A >> mat;
-        for (Int_t j = 0; j < npol + 1; j++)
-            fpar >> par[j];
-        fpar >> dummy >> dummy;
-        if (fpar.eof())
-            break;
-        vZ.emplace_back(Z);
-        vA.emplace_back(A);
-        vmat.emplace_back(mat);
-        for (Int_t j = 0; j < npol + 1; j++)
-            vpar[j].emplace_back(par[j]);
-    }
-    fpar.close();
-    if (vZ.size() == 0) {
-        std::cout << "No isotope data loaded." << std::endl;
-    }
-
-    Int_t self_index = this->size();
-    for (Size_t i = 0; i < vZ.size(); i++) {
-        /// register the mapping
-        // Do nothing if the key already exists
-        auto mat_result = mat_mapping.insert({std::string(vmat.at(i).Data()), Nmat});
-        if (mat_result.second)
-            Nmat++;
-
-        if (auto it = mat_mapping.find(std::string(vmat.at(i).Data())); it != mat_mapping.end()) {
-            auto result = self_mapping.insert({get_key(vZ.at(i), vA.at(i), it->second), self_index});
-            if (!result.second) {
-                std::cerr << "Key already exists with index: " << result.first->second << std::endl;
-            } else {
-                this->emplace_back(TF1(Form("%d-%d_%s", vZ.at(i), vA.at(i), vmat.at(i).Data()),
-                                       fn_name.Data(), TSrim::log10Emin,
-                                       TSrim::log10Emaxpu * Mass(Z, A)));
-                for (Int_t j = 0; j < npol + 1; j++) {
-                    this->at(self_index).SetParameter(j, vpar[j].at(i));
-                }
-                self_index++;
-            }
-        }
-    }
+    TSrim::AddElement(name, npol, datafile, -1, -1, -1, -1);
 }
-
 void TSrim::AddElement(const char *name, const Int_t npol, const char *datafile,
                        Int_t Z, Int_t A) {
+    TSrim::AddElement(name, npol, datafile, Z, A, -1, -1);
+}
+void TSrim::AddElement(const char *name, const Int_t npol, const char *datafile,
+                       Int_t Zmin, Int_t Amin, Int_t Zmax, Int_t Amax) {
     TString fn_name = Form("pol%d", npol);
     Double_t dummy;
     Int_t Zdat, Adat;
-    TString mat;
+    std::string mat;
     Double_t par[npol + 1];
     vector<Int_t> vZ, vA;
-    vector<TString> vmat;
+    vector<std::string> vmat;
     vector<Double_t> vpar[npol + 1];
+
+    auto addData = [&](Int_t Zdat, Int_t Adat, const std::string &mat, const Double_t *par) {
+        vZ.emplace_back(Zdat);
+        vA.emplace_back(Adat);
+        vmat.emplace_back(mat);
+        for (Int_t j = 0; j < npol + 1; ++j) {
+            vpar[j].emplace_back(par[j]);
+        }
+    };
+
     std::ifstream fpar(datafile);
     while (!fpar.eof()) {
         fpar >> Zdat >> Adat >> mat;
         for (Int_t j = 0; j < npol + 1; j++)
             fpar >> par[j];
         fpar >> dummy >> dummy;
-        if (fpar.eof()) {
-            break;
-        }
-        if (Zdat == Z && Adat == A) {
-            vZ.emplace_back(Z);
-            vA.emplace_back(A);
-            vmat.emplace_back(mat);
-            for (Int_t j = 0; j < npol + 1; j++)
-                vpar[j].emplace_back(par[j]);
-            break;
-        }
-    }
-    fpar.close();
-    if (vZ.size() == 0) {
-        std::cout << "No isotope data loaded." << std::endl;
-    }
-
-    Int_t self_index = this->size();
-    for (Size_t i = 0; i < vZ.size(); i++) {
-        /// register the mapping
-        // Do nothing if the key already exists
-        auto mat_result = mat_mapping.insert({std::string(vmat.at(i).Data()), Nmat});
-        if (mat_result.second)
-            Nmat++;
-
-        if (auto it = mat_mapping.find(std::string(vmat.at(i).Data())); it != mat_mapping.end()) {
-            auto result = self_mapping.insert({get_key(vZ.at(i), vA.at(i), it->second), self_index});
-            if (!result.second) {
-                std::cerr << "Key already exists with index: " << result.first->second << std::endl;
-            } else {
-                this->emplace_back(TF1(Form("%d-%d_%s", vZ.at(i), vA.at(i), vmat.at(i).Data()),
-                                       fn_name.Data(), TSrim::log10Emin,
-                                       TSrim::log10Emaxpu * Mass(Z, A)));
-                for (Int_t j = 0; j < npol + 1; j++) {
-                    this->at(self_index).SetParameter(j, vpar[j].at(i));
-                }
-                self_index++;
-            }
-        }
-    }
-}
-
-void TSrim::AddElement(const char *name, const Int_t npol, const char *datafile,
-                       Int_t Zmin, Int_t Amin, Int_t Zmax, Int_t Amax) {
-    TString fn_name = Form("pol%d", npol);
-    Double_t dummy;
-    Int_t Z, A;
-    TString mat;
-    Double_t par[npol + 1];
-    vector<Int_t> vZ, vA;
-    vector<TString> vmat;
-    vector<Double_t> vpar[npol + 1];
-    std::ifstream fpar(datafile);
-    while (!fpar.eof()) {
-        fpar >> Z >> A >> mat;
-        for (Int_t j = 0; j < npol + 1; j++)
-            fpar >> par[j];
-        fpar >> dummy >> dummy;
         if (fpar.eof())
             break;
-        if (Z >= Zmin && A >= Amin && Z <= Zmax && A <= Amax) {
-            vZ.emplace_back(Z);
-            vA.emplace_back(A);
-            vmat.emplace_back(mat);
-            for (Int_t j = 0; j < npol + 1; j++)
-                vpar[j].emplace_back(par[j]);
+
+        if (Zmin == -1 && Amin == -1 && Zmax == -1 && Amax == -1) {
+            addData(Zdat, Adat, mat, par);
+        } else if (Zmin != -1 && Amin != -1 && Zdat == Zmin && Adat == Amin) {
+            addData(Zdat, Adat, mat, par);
+            break;
+        } else if (Zdat >= Zmin && Adat >= Amin && Zdat <= Zmax && Adat <= Amax) {
+            addData(Zdat, Adat, mat, par);
         }
     }
     fpar.close();
@@ -725,18 +480,19 @@ void TSrim::AddElement(const char *name, const Int_t npol, const char *datafile,
     for (Size_t i = 0; i < vZ.size(); i++) {
         /// register the mapping
         // Do nothing if the key already exists
-        auto mat_result = mat_mapping.insert({std::string(vmat.at(i).Data()), Nmat});
+        auto mat_result = mat_mapping.emplace(vmat.at(i), Nmat);
         if (mat_result.second)
             Nmat++;
 
-        if (auto it = mat_mapping.find(std::string(vmat.at(i).Data())); it != mat_mapping.end()) {
-            auto result = self_mapping.insert({get_key(vZ.at(i), vA.at(i), it->second), self_index});
+        if (auto it = mat_mapping.find(vmat.at(i)); it != mat_mapping.end()) {
+            auto result = self_mapping.emplace(get_key(vZ.at(i), vA.at(i), it->second), self_index);
             if (!result.second) {
-                std::cerr << "Key already exists with index: " << result.first->second << std::endl;
+                std::cerr << "Z: " << vZ.at(i) << ", A: " << vA.at(i) << ", mat: " << vmat.at(i)
+                          << " already exists with index: " << result.first->second << std::endl;
             } else {
-                this->emplace_back(TF1(Form("%d-%d_%s", vZ.at(i), vA.at(i), vmat.at(i).Data()),
+                this->emplace_back(TF1(Form("%d-%d_%s", vZ.at(i), vA.at(i), vmat.at(i).c_str()),
                                        fn_name.Data(), TSrim::log10Emin,
-                                       TSrim::log10Emaxpu * Mass(Z, A)));
+                                       TSrim::log10Emaxpu * amdc::Mass(vZ.at(i), vA.at(i))));
                 for (Int_t j = 0; j < npol + 1; j++) {
                     this->at(self_index).SetParameter(j, vpar[j].at(i));
                 }

--- a/TSrim.cc
+++ b/TSrim.cc
@@ -189,7 +189,6 @@ TSrim::TSrim(const char *name, const Int_t npol, const char *datafile,
         }
     }
 };
-TSrim::~TSrim() {}
 ///////////////////////////////////////////////////////////////////////////////
 Double_t TSrim::Range(Int_t Z, Int_t A, Double_t E, TString mat) {
     if (E <= TSrim::Emin) {

--- a/TSrim.h
+++ b/TSrim.h
@@ -111,9 +111,10 @@ class TSrim : public std::vector<TF1> {
 
     Int_t GetNmaterial() const { return Nmat; }
 
+    static constexpr Double_t T0 = 273.15;
+    static constexpr Double_t P1 = 760.;
+
   private:
-    const Double_t T0 = 273.15;
-    const Double_t P1 = 760.;
     const Double_t Emin = 0.001;  // MeV
     const Double_t Emaxpu = 400.; // MeV/u
     const Double_t log10Emin = log10(Emin);

--- a/TSrim.h
+++ b/TSrim.h
@@ -16,7 +16,7 @@ class TSrim : public std::vector<TF1> {
           Int_t Z, Int_t A);
     TSrim(const char *name, const Int_t npol, const char *datafile,
           Int_t Zmin, Int_t Amin, Int_t Zmax, Int_t Amax);
-    virtual ~TSrim();
+    virtual ~TSrim() = default;
     //////////////////////////////////////////////////////////////////////////
     // Range in a material of an ion at an energy
     Double_t Range(Int_t Z, Int_t A, Double_t E, TString mat);


### PR DESCRIPTION
### Summary

`TSrim`クラスのコードを今後修正しやすくなるような変更を加えました。
今後は[こちら](https://github.com/CRIB-project/TSrim/discussions/1)にアイデアをまとめたので、便利そうなものは取り入れていただければと思います。

### Changes

1. デストラクタにdefaultを使用

    デストラクタで、特別な処理を行っていなかったので、`= default`を使って、デフォルトのものを使うようにしました。

2. `T0`、`P1`変数をpublic変数にする

    外部ライブラリから、使用する際に、温度と圧力をデフォルトの値を用いたい時があったので、外部からアクセスできるようにpublic変数にした方が良いかなと思い、移動させました。

3. `AddElement`の使用

    複数のコンストラクタに対して、ほとんど同じ処理がされていた部分を、まとめて一箇所で記述できるようにしました。

### Risks

大まかには、こちらの変更で動くことを確認していますが、以前のバージョンと完全に同じ動作をするかは確認していただければと思います。